### PR TITLE
Detect dependencies called by use

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^cran-comments\.md$
 ^codemeta\.json$
 ^CRAN-SUBMISSION$
+^\.here$
+^air\.toml$

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 README.html
 inst/doc
 CRAN-SUBMISSION
+
+/.quarto/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rdeps
 Type: Package
 Title: Identify External Packages Used in a Project
-Version: 0.2
+Version: 0.3
 Authors@R: c(
     person(given   = "Nicolas",
            family  = "Casajus",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# rdeps 0.2.9000 (development version)
+# rdeps 0.3
 
+* New feature: detect packages called by `use()` as suggested in [#2](https://github.com/FRBCesab/rdeps/issues/2)
 
 # rdeps 0.2
 

--- a/R/add_deps.R
+++ b/R/add_deps.R
@@ -10,13 +10,14 @@
 #'
 #' All `.R`, `.Rmd`, and `.qmd` files are screened to identify packages
 #' called by `library(foo)`, `library("foo")`, `library('foo')`,
-#' `require(foo)`, `require("foo")`, `require('foo')` or `foo::bar()`.
+#' `require(foo)`, `require("foo")`, `require('foo')`, `foo::bar()` or
+#' `use("foo", "bar")`.
 #'
 #' Different types of dependencies are handled with the following rules:
 #' - if a package is called with `library(foo)` or `require(foo)`,
 #' it will be added to the section **Depends** of the `DESCRIPTION` file
 #' (except for vignettes and tests);
-#' - if the package is called with `foo::bar()`,
+#' - if the package is called with `foo::bar()` or `use("foo", "bar")`,
 #' it will be added to the section **Imports** of the `DESCRIPTION` file
 #' (except for vignettes and tests);
 #' - if the package is only used in vignettes or tests,

--- a/R/add_deps.R
+++ b/R/add_deps.R
@@ -1,38 +1,38 @@
 #' Add required dependencies to the description file
-#' 
-#' @description 
-#' This function detects external packages used in an R project (package, 
-#' compendium, website, etc.) and updates the sections **Depends**, 
+#'
+#' @description
+#' This function detects external packages used in an R project (package,
+#' compendium, website, etc.) and updates the sections **Depends**,
 #' **Imports**, and **Suggests** of the `DESCRIPTION` file.
-#' 
-#' A `DESCRIPTION` file can be created and added to an existing project with 
+#'
+#' A `DESCRIPTION` file can be created and added to an existing project with
 #' the function `use_description()` of the package `usethis`.
-#'  
-#' All `.R`, `.Rmd`, and `.qmd` files are screened to identify packages 
-#' called by `library(foo)`, `library("foo")`, `library('foo')`, 
+#'
+#' All `.R`, `.Rmd`, and `.qmd` files are screened to identify packages
+#' called by `library(foo)`, `library("foo")`, `library('foo')`,
 #' `require(foo)`, `require("foo")`, `require('foo')` or `foo::bar()`.
-#' 
+#'
 #' Different types of dependencies are handled with the following rules:
-#' - if a package is called with `library(foo)` or `require(foo)`, 
-#' it will be added to the section **Depends** of the `DESCRIPTION` file 
+#' - if a package is called with `library(foo)` or `require(foo)`,
+#' it will be added to the section **Depends** of the `DESCRIPTION` file
 #' (except for vignettes and tests);
 #' - if the package is called with `foo::bar()`,
 #' it will be added to the section **Imports** of the `DESCRIPTION` file
 #' (except for vignettes and tests);
 #' - if the package is only used in vignettes or tests,
 #' it will be added to the section **Suggests** of the `DESCRIPTION` file.
-#' 
-#' This function also screens the `NAMESPACE` file (it detects packages 
-#' mentioned as `import(foo)` and `importFrom(foo,bar)`) and `@examples` 
-#' sections of `roxygen2` headers. The detected packages are added in the 
+#'
+#' This function also screens the `NAMESPACE` file (it detects packages
+#' mentioned as `import(foo)` and `importFrom(foo,bar)`) and `@examples`
+#' sections of `roxygen2` headers. The detected packages are added in the
 #' **Imports** section of the `DESCRIPTION` file.
-#' 
+#'
 #' If the project is not an R package, non-standard folders are also screened
-#' (i.e. `analyses/`, `paper/`, etc.). The detected packages are added in the 
-#' **Imports** section of the `DESCRIPTION` file. 
-#' 
+#' (i.e. `analyses/`, `paper/`, etc.). The detected packages are added in the
+#' **Imports** section of the `DESCRIPTION` file.
+#'
 #' @return No return value.
-#'   
+#'
 #' @export
 #'
 #' @examples
@@ -41,211 +41,209 @@
 #' }
 
 add_deps <- function() {
-  
   check_for_descr_file()
   path <- path_proj()
-  
-  
+
   ## Identify dependencies ----
-  
-  deps_in_namespace       <- get_deps_in_namespace()
-  deps_in_functions_r     <- get_deps_in_functions(directory = "R")
-  deps_in_examples_r      <- get_deps_in_examples(directory = "R")
-  
-  deps_in_vignettes       <- get_deps_in_markdown(directory = "vignettes")
+
+  deps_in_namespace <- get_deps_in_namespace()
+  deps_in_functions_r <- get_deps_in_functions(directory = "R")
+  deps_in_examples_r <- get_deps_in_examples(directory = "R")
+
+  deps_in_vignettes <- get_deps_in_markdown(directory = "vignettes")
   deps_in_functions_tests <- get_deps_in_functions(directory = "tests")
-  deps_in_examples_tests  <- get_deps_in_examples(directory = "tests")
-  deps_in_markdown_tests  <- get_deps_in_markdown(directory = "tests")
-  
-  deps_in_extra           <- get_deps_in_extra()
-  
-  
+  deps_in_examples_tests <- get_deps_in_examples(directory = "tests")
+  deps_in_markdown_tests <- get_deps_in_markdown(directory = "tests")
+
+  deps_in_extra <- get_deps_in_extra()
+
   ## Order SUGGESTS dependencies ----
-  
-  deps_suggests <- c(unlist(deps_in_vignettes), 
-                     unlist(deps_in_functions_tests),
-                     unlist(deps_in_examples_tests),
-                     unlist(deps_in_markdown_tests))
-  
+
+  deps_suggests <- c(
+    unlist(deps_in_vignettes),
+    unlist(deps_in_functions_tests),
+    unlist(deps_in_examples_tests),
+    unlist(deps_in_markdown_tests)
+  )
+
   deps_suggests <- sort(unique(deps_suggests))
-  
-  
+
   ## Order IMPORTS dependencies ----
-  
-  deps_imports <- c(deps_in_namespace,
-                    deps_in_functions_r$"imports",
-                    deps_in_examples_r$"imports", 
-                    deps_in_extra$"imports")
-  
+
+  deps_imports <- c(
+    deps_in_namespace,
+    deps_in_functions_r$"imports",
+    deps_in_examples_r$"imports",
+    deps_in_extra$"imports"
+  )
+
   deps_imports <- sort(unique(deps_imports))
-  
-  
+
   ## Order DEPENDS dependencies ----
-  
-  deps_depends <- c(deps_in_functions_r$"depends",
-                    deps_in_examples_r$"depends", 
-                    deps_in_extra$"depends")
-  
+
+  deps_depends <- c(
+    deps_in_functions_r$"depends",
+    deps_in_examples_r$"depends",
+    deps_in_extra$"depends"
+  )
+
   deps_depends <- sort(unique(deps_depends))
-  
-  
+
   ## Remove duplicates ----
-  
+
   pos <- which(deps_suggests %in% deps_imports)
   if (length(pos) > 0) deps_suggests <- deps_suggests[-pos]
-  
+
   pos <- which(deps_imports %in% deps_depends)
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Clean objects ----
-  
-  if (length(deps_depends) == 0)  deps_depends  <- NULL
-  if (length(deps_imports) == 0)  deps_imports  <- NULL
+
+  if (length(deps_depends) == 0) deps_depends <- NULL
+  if (length(deps_imports) == 0) deps_imports <- NULL
   if (length(deps_suggests) == 0) deps_suggests <- NULL
-  
-  
+
   ## Read DESCRIPTION file and extract dependencies ----
-  
+
   descr_file <- read_descr_file()
-  
-  descr_depends  <- get_deps_in_depends()
-  descr_imports  <- get_deps_in_imports()
+
+  descr_depends <- get_deps_in_depends()
+  descr_imports <- get_deps_in_imports()
   descr_suggests <- get_deps_in_suggests()
-  
-  
+
   ## Detect version ----
-  
+
   all_deps <- c(descr_depends, descr_imports, descr_suggests)
-  
+
   if (!is.null(all_deps)) {
-    
     versions <- strsplit(all_deps, "\\s{0,}\\(|\\)")
-    
+
     is_version <- unlist(lapply(versions, function(x) {
       if (length(x) == 2) TRUE else FALSE
     }))
-    
+
     versions <- versions[is_version]
-    pkg_names    <- unlist(lapply(versions, function(x) x[1]))
+    pkg_names <- unlist(lapply(versions, function(x) x[1]))
     pkg_versions <- unlist(lapply(versions, function(x) x[2]))
-    
   } else {
-    
-    pkg_names    <- NULL
+    pkg_names <- NULL
     pkg_versions <- NULL
   }
-  
-  
+
   ## Add version to packages ----
-  
+
   if (!is.null(pkg_names)) {
-    
     for (i in 1:length(pkg_names)) {
-      
       pos <- which(deps_depends == pkg_names[i])
-      
+
       if (length(pos) == 1) {
         deps_depends[pos] <- paste0(pkg_names[i], " (", pkg_versions[i], ")")
       }
-      
+
       pos <- which(deps_imports == pkg_names[i])
-      
+
       if (length(pos) == 1) {
         deps_imports[pos] <- paste0(pkg_names[i], " (", pkg_versions[i], ")")
       }
-      
+
       pos <- which(deps_suggests == pkg_names[i])
-      
+
       if (length(pos) == 1) {
         deps_suggests[pos] <- paste0(pkg_names[i], " (", pkg_versions[i], ")")
       }
     }
   }
-  
-  
+
   ## Add R minimum version ----
-  
+
   deps_depends <- c(r_min_version(), deps_depends)
-  
-  
+
   ## Add packages in DESCRIPTION file ----
-  
+
   msg_info("Searching for", msg_value('Depends'), "dependencies")
-  
+
   if (is.null(deps_depends)) {
-    
     pos <- which(colnames(descr_file) == "Depends")
-    if (length(pos)) descr_file <- descr_file[ , -pos]
-    
+    if (length(pos)) descr_file <- descr_file[, -pos]
+
     msg_oops("No package found", indent = "    ")
-    
   } else {
-    
     deps_depends_txt <- paste0(deps_depends, collapse = ",\n    ")
     descr_file$"Depends" <- paste0("\n    ", deps_depends_txt)
-    
-    msg_done("Found", msg_value(length(deps_depends)), "package(s)", 
-             indent = "    ")
-    
+
+    msg_done(
+      "Found",
+      msg_value(length(deps_depends)),
+      "package(s)",
+      indent = "    "
+    )
+
     msg <- paste0("Depends: ", paste0(deps_depends, collapse = ", "))
-    msg_done("Adding the following line in", msg_value('DESCRIPTION'),
-             indent = "    ")
+    msg_done(
+      "Adding the following line in",
+      msg_value('DESCRIPTION'),
+      indent = "    "
+    )
     msg_line(msg_code(msg), indent = "      ")
   }
-  
-  
+
   msg_info("Searching for", msg_value('Imports'), "dependencies")
-  
+
   if (is.null(deps_imports)) {
-    
     pos <- which(colnames(descr_file) == "Imports")
-    if (length(pos)) descr_file <- descr_file[ , -pos]
-    
+    if (length(pos)) descr_file <- descr_file[, -pos]
+
     msg_oops("No package found", indent = "    ")
-    
   } else {
-    
     deps_imports_txt <- paste0(deps_imports, collapse = ",\n    ")
     descr_file$"Imports" <- paste0("\n    ", deps_imports_txt)
-    
-    msg_done("Found", msg_value(length(deps_imports)), "package(s)", 
-             indent = "    ")
-    
+
+    msg_done(
+      "Found",
+      msg_value(length(deps_imports)),
+      "package(s)",
+      indent = "    "
+    )
+
     msg <- paste0("Imports: ", paste0(deps_imports, collapse = ", "))
-    msg_done("Adding the following line in", msg_value('DESCRIPTION'),
-             indent = "    ")
+    msg_done(
+      "Adding the following line in",
+      msg_value('DESCRIPTION'),
+      indent = "    "
+    )
     msg_line(msg_code(msg), indent = "      ")
   }
-  
-  
+
   msg_info("Searching for", msg_value('Suggests'), "dependencies")
-  
+
   if (is.null(deps_suggests)) {
-    
     pos <- which(colnames(descr_file) == "Suggests")
-    if (length(pos)) descr_file <- descr_file[ , -pos]
-    
+    if (length(pos)) descr_file <- descr_file[, -pos]
+
     msg_oops("No package found", indent = "    ")
-    
   } else {
-    
     deps_suggests_txt <- paste0(deps_suggests, collapse = ",\n    ")
     descr_file$"Suggests" <- paste0("\n    ", deps_suggests_txt)
-    
-    msg_done("Found", msg_value(length(deps_suggests)), "package(s)", 
-             indent = "    ")
-    
+
+    msg_done(
+      "Found",
+      msg_value(length(deps_suggests)),
+      "package(s)",
+      indent = "    "
+    )
+
     msg <- paste0("Suggests: ", paste0(deps_suggests, collapse = ", "))
-    msg_done("Adding the following line in", msg_value('DESCRIPTION'),
-             indent = "    ")
+    msg_done(
+      "Adding the following line in",
+      msg_value('DESCRIPTION'),
+      indent = "    "
+    )
     msg_line(msg_code(msg), indent = "      ")
   }
-  
-  
+
   ## Rewrite DESCRIPTION ----
-  
+
   write_descr_file(descr_file)
-  
+
   invisible(NULL)
 }

--- a/R/rdeps-package.R
+++ b/R/rdeps-package.R
@@ -1,7 +1,7 @@
 #' @keywords internal
 "_PACKAGE"
 
-# Imports: start ---- 
+# Imports: start ----
 # Imports: end ----
 
 NULL

--- a/R/utils-deps.R
+++ b/R/utils-deps.R
@@ -1,136 +1,113 @@
 #' **Detect dependencies in Depends field of DESCRIPTION**
-#' 
+#'
 #' @noRd
 
 get_deps_in_depends <- function() {
-  
   descr <- read_descr_file()
-  
+
   if (!is.null(descr$"Depends")) {
-    
     deps <- get_deps_in_field(descr$"Depends")
-    
   } else {
-    
     deps <- NULL
   }
-  
+
   deps
 }
-
 
 
 #' **Detect dependencies in Imports field of DESCRIPTION**
-#' 
+#'
 #' @noRd
 
 get_deps_in_imports <- function() {
-  
   descr <- read_descr_file()
-  
+
   if (!is.null(descr$"Imports")) {
-    
     deps <- get_deps_in_field(descr$"Imports")
-    
   } else {
-    
     deps <- NULL
   }
-  
+
   deps
 }
-
 
 
 #' **Detect dependencies in Suggests field of DESCRIPTION**
-#' 
+#'
 #' @noRd
 
 get_deps_in_suggests <- function() {
-  
   descr <- read_descr_file()
-  
+
   if (!is.null(descr$"Suggests")) {
-    
     deps <- get_deps_in_field(descr$"Suggests")
-    
   } else {
-    
     deps <- NULL
   }
-  
+
   deps
 }
 
 
-
 #' **Get R minimum version**
-#' 
+#'
 #' @noRd
 
 r_min_version <- function() {
-  
   check_for_descr_file()
-  
+
   descr_file <- read_descr_file()
-  
+
   if ("Depends" %in% colnames(descr_file)) {
-    
     deps <- unlist(strsplit(descr_file$"Depends", ","))
-    
+
     deps <- gsub("\\(\\s{0,}", " (", deps)
     deps <- gsub("\\s{0,}\\)", ")", deps)
     deps <- gsub("=", "= ", deps)
     deps <- gsub(">", "> ", deps)
     deps <- gsub("<", "< ", deps)
-    
+
     deps <- gsub("\\s{0,}\\)", ")", deps)
     deps <- gsub("\\s+", " ", deps)
     deps <- trimws(deps)
-    
+
     deps <- gsub("< =", "<=", deps)
     deps <- gsub("> =", ">=", deps)
     deps <- gsub("= =", "==", deps)
-    
+
     r_version <- deps[grep("^R\\s{0,}\\(", deps)]
-    
+
     if (length(r_version) == 0) {
-      
       r_version <- NULL
     }
-    
   } else {
-    
     r_version <- NULL
   }
-  
+
   r_version
 }
 
 
 #' **Remove R minimum version from list of packages**
-#' 
+#'
 #' @noRd
 
 remove_r_min_version <- function(dependencies) {
-  
   r_version <- grep("^R\\s{0,}\\(", dependencies)
-  
+
   if (length(r_version)) {
     dependencies <- dependencies[-r_version]
   }
-  
+
   dependencies
 }
 
 
-
 #' **Extract and clean list of packages in a particular DESCRIPTION field**
-#' 
+#'
 #' @noRd
 
 get_deps_in_field <- function(field) {
-  
   deps <- unlist(strsplit(field, "\n\\s{0,}|,|,\\s{0,}"))
 
   deps <- gsub("\\(\\s{0,}", " (", deps)
@@ -138,694 +115,659 @@ get_deps_in_field <- function(field) {
   deps <- gsub("=", "= ", deps)
   deps <- gsub(">", "> ", deps)
   deps <- gsub("<", "< ", deps)
-  
+
   deps <- gsub("\\s{0,}\\)", ")", deps)
   deps <- gsub("\\s+", " ", deps)
   deps <- trimws(deps)
-  
+
   deps <- gsub("< =", "<=", deps)
   deps <- gsub("> =", ">=", deps)
   deps <- gsub("= =", "==", deps)
-  
+
   deps <- deps[!(deps == "")]
-  
+
   remove_r_min_version(deps)
 }
 
 
-
 #' **Extract and clean list of packages in NAMESPACE**
-#' 
+#'
 #' Detect dependencies as `import(pkg)` and `importFrom(pkg,fun)`.
-#' 
+#'
 #' @noRd
 
 get_deps_in_namespace <- function() {
-  
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
+
   if (file.exists(file.path(path, "NAMESPACE"))) {
-    
     namespace <- readLines(con = file.path(path, "NAMESPACE"), warn = FALSE)
     namespace <- namespace[grep("^\\s{0,}import", namespace)]
-    
+
     deps <- gsub("importFrom\\s{0,}\\(|import\\s{0,}\\(|\\)", "", namespace)
     deps <- gsub("\\s+", " ", deps)
     deps <- trimws(deps)
-    
+
     if (length(deps) == 0) {
-      
       deps <- NULL
-      
     } else {
-      
       deps <- strsplit(deps, "\\s{0,},\\s{0,}")
       deps <- lapply(deps, function(x) x[1])
       deps <- sort(unique(unlist(deps)))
     }
-    
   } else {
-    
     deps <- NULL
   }
-  
+
   deps
 }
 
 
-
 #' **Extract and clean list of packages in the R folder**
-#' 
+#'
 #' Detect dependencies in R functions written as `foo::bar()`, `library(foo)`,
-#' `library("foo")`, `library('foo')`, `require(foo)`, `require("foo")`, 
+#' `library("foo")`, `library('foo')`, `require(foo)`, `require("foo")`,
 #' `require('foo')`.
-#' 
+#'
 #' @return A named `list` of two `character` vectors:
 #'   - `depends`, packages called with `library(foo)` and `require(foo)`;
 #'   - `imports`, packages called with `foo:bar()`.
-#'   
+#'
 #' If a package is called with `library(foo)` and `foo:bar()`, it will be added
 #' only to `depends`.
-#' 
+#'
 #' @noRd
 
 get_deps_in_functions <- function(directory = "R") {
-  
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
-  
+
   ## No `directory` folder ----
-  
+
   if (!dir.exists(file.path(path, directory))) {
-    
-    return(list("depends" = NULL,"imports" = NULL))
+    return(list("depends" = NULL, "imports" = NULL))
   }
-  
-  
-  r_files <- list.files(path = file.path(path, directory), pattern = "\\.R$", 
-                        full.names = TRUE, ignore.case = TRUE, recursive = TRUE)
-  
-  r_files <- c(r_files,
-               list.files(path = file.path(path), pattern = "\\.R$", 
-                          full.names = TRUE, ignore.case = TRUE, 
-                          recursive = FALSE))
-  
-  
+
+  r_files <- list.files(
+    path = file.path(path, directory),
+    pattern = "\\.R$",
+    full.names = TRUE,
+    ignore.case = TRUE,
+    recursive = TRUE
+  )
+
+  r_files <- c(
+    r_files,
+    list.files(
+      path = file.path(path),
+      pattern = "\\.R$",
+      full.names = TRUE,
+      ignore.case = TRUE,
+      recursive = FALSE
+    )
+  )
+
   ## No .R files in `directory` ----
-  
+
   if (!length(r_files)) {
-    
-    return(list("depends" = NULL,"imports" = NULL))
+    return(list("depends" = NULL, "imports" = NULL))
   }
-    
-    
+
   ## Read R files ----
-  
+
   content <- lapply(r_files, function(x) readLines(con = x, warn = FALSE))
-  
-  
+
   ## Remove comments ----
-  
+
   content <- remove_comment_lines(content)
-  
-  
+
   ## Remove messages ----
-  
+
   content <- remove_messages(content)
-  
-  
+
   ## Functions called as pkg::fun() ----
-  
+
   deps_imports <- get_colon_syntax_deps(content)
-  
-  
+
   ## Attached Packages (library & require) ----
-  
+
   deps_depends <- get_attached_deps(content)
-  
-  
+
   ## Remove duplicates ----
-  
+
   pos <- which(deps_imports %in% deps_depends)
-  
+
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Remove project name ----
-  
+
   pos <- which(deps_depends == basename(path))
   if (length(pos) > 0) deps_depends <- deps_depends[-pos]
-  
+
   pos <- which(deps_imports == basename(path))
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Clean objects ----
-  
+
   if (length(deps_depends) == 0) deps_depends <- NULL
   if (length(deps_imports) == 0) deps_imports <- NULL
-  
+
   list("depends" = deps_depends, "imports" = deps_imports)
 }
 
 
-
 #' **Detect dependencies in @examples**
-#' 
+#'
 #' Detect dependencies in **@examples** written as `foo::bar()`, `library(foo)`,
-#' `library("foo")`, `library('foo')`, `require(foo)`, `require("foo")`, 
+#' `library("foo")`, `library('foo')`, `require(foo)`, `require("foo")`,
 #' `require('foo')`.
-#' 
+#'
 #' @return A named `list` of two `character` vectors:
 #'   - `depends`, packages called with `library(foo)` and `require(foo)`;
 #'   - `imports`, packages called with `foo:bar()`.
-#'   
+#'
 #' If a package is called with `library(foo)` and `foo:bar()`, it will be added
 #' only to `depends`.
-#' 
+#'
 #' @noRd
 
-get_deps_in_examples <- function(directory = "R") { 
-  
+get_deps_in_examples <- function(directory = "R") {
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
-  
+
   ## No `directory` folder ----
-  
+
   if (!dir.exists(file.path(path, directory))) {
-    
-    return(list("depends" = NULL,"imports" = NULL))
+    return(list("depends" = NULL, "imports" = NULL))
   }
-  
-  
-  r_files <- list.files(path = file.path(path, directory), pattern = "\\.R$", 
-                        full.names = TRUE, ignore.case = TRUE, recursive = TRUE)
-  
-  r_files <- c(r_files,
-               list.files(path = file.path(path), pattern = "\\.R$", 
-                          full.names = TRUE, ignore.case = TRUE, 
-                          recursive = FALSE))
-  
+
+  r_files <- list.files(
+    path = file.path(path, directory),
+    pattern = "\\.R$",
+    full.names = TRUE,
+    ignore.case = TRUE,
+    recursive = TRUE
+  )
+
+  r_files <- c(
+    r_files,
+    list.files(
+      path = file.path(path),
+      pattern = "\\.R$",
+      full.names = TRUE,
+      ignore.case = TRUE,
+      recursive = FALSE
+    )
+  )
+
   ## No .R files in `directory` ----
-  
+
   if (!length(r_files)) {
-    
-    return(list("depends" = NULL,"imports" = NULL))
+    return(list("depends" = NULL, "imports" = NULL))
   }
-  
-  
+
   ## Read R files ----
-    
+
   content <- lapply(r_files, function(x) readLines(con = x, warn = FALSE))
-  
-  
+
   ## Select roxygen2 headers ----
-  
+
   content <- lapply(content, function(x) x[grep("^\\s{0,}#'", x)])
-  
-  
+
   ## Select @examples sections (dirty code, but working) ----
-  
+
   ex_start <- lapply(content, function(x) grep("^\\s{0,}#'\\s{0,}@examples", x))
-  ex_end   <- lapply(content, function(x) grep("#'\\s{0,}@", x))
-  
+  ex_end <- lapply(content, function(x) grep("#'\\s{0,}@", x))
+
   examples <- list()
-  
+
   for (i in seq_len(length(ex_start))) {
-    
     examples[[i]] <- character(0)
-    
+
     if (length(ex_start[[i]])) {
-      
       for (j in seq_len(length(ex_start[[i]]))) {
-        
-        pos <- ex_end[[i]][ex_end[[i]] > ex_start[[i]][j]] 
-        
+        pos <- ex_end[[i]][ex_end[[i]] > ex_start[[i]][j]]
+
         if (length(pos)) {
-          
           examples[[i]] <- c(
             examples[[i]],
-            content[[i]][(ex_start[[i]][j] + 1):(pos[1] - 1)])
-          
+            content[[i]][(ex_start[[i]][j] + 1):(pos[1] - 1)]
+          )
         } else {
-          
           examples[[i]] <- c(
             examples[[i]],
-            content[[i]][(ex_start[[i]][j] + 1):length(content[[i]])])
+            content[[i]][(ex_start[[i]][j] + 1):length(content[[i]])]
+          )
         }
       }
     }
   }
-  
+
   content <- examples
-  
-  
+
   ## Remove comments ----
-  
+
   content <- remove_rd_comment_lines(content)
-  
-  
+
   ## Remove messages ----
-  
+
   content <- remove_messages(content)
-  
-  
+
   ## Functions called as pkg::fun() ----
-  
+
   deps_imports <- get_colon_syntax_deps(content)
-  
-  
+
   ## Attached Packages (library & require) ----
-  
+
   deps_depends <- get_attached_deps(content)
-  
-  
+
   ## Remove duplicates ----
-  
+
   pos <- which(deps_imports %in% deps_depends)
-  
+
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Remove project name ----
-  
+
   pos <- which(deps_depends == basename(path))
   if (length(pos) > 0) deps_depends <- deps_depends[-pos]
-  
+
   pos <- which(deps_imports == basename(path))
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Clean objects ----
-  
+
   if (length(deps_depends) == 0) deps_depends <- NULL
   if (length(deps_imports) == 0) deps_imports <- NULL
-  
+
   list("depends" = deps_depends, "imports" = deps_imports)
 }
 
 
-
 #' **Detect dependencies in Markdown files**
-#' 
-#' Detect dependencies in `.Rmd` and `.qmd` as `pkg::fun()`, `library(pkg)`, 
+#'
+#' Detect dependencies in `.Rmd` and `.qmd` as `pkg::fun()`, `library(pkg)`,
 #' and `require(pkg)`.
-#' 
+#'
 #' If `.Rmd` files are detected, the packages `knitr` and `rmarkdown` are added
 #' to the list of packages.
-#' 
-#' If `.qmd` files are detected, the package `quarto` is added to the list of 
+#'
+#' If `.qmd` files are detected, the package `quarto` is added to the list of
 #' packages.
-#' 
+#'
 #' @noRd
 
-get_deps_in_markdown <- function(directory = "vignettes") { 
-  
+get_deps_in_markdown <- function(directory = "vignettes") {
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
-  
+
   ## No `directory` folder ----
-  
+
   if (!dir.exists(file.path(path, directory))) {
-    
-    return(list("depends" = NULL,"imports" = NULL))
+    return(list("depends" = NULL, "imports" = NULL))
   }
-  
-  
+
   packages_to_add <- NULL
-  
-  
+
   ## Search for Rmd ----
-  
-  rmd_files <- list.files(path = file.path(path, directory), 
-                          pattern = "\\.Rmd$", full.names = TRUE, 
-                          ignore.case = TRUE, recursive = TRUE)
-  
-  rmd_files <- c(rmd_files,
-                 list.files(path = file.path(path), pattern = "\\.Rmd$", 
-                            full.names = TRUE, ignore.case = TRUE, 
-                            recursive = FALSE))
-  
+
+  rmd_files <- list.files(
+    path = file.path(path, directory),
+    pattern = "\\.Rmd$",
+    full.names = TRUE,
+    ignore.case = TRUE,
+    recursive = TRUE
+  )
+
+  rmd_files <- c(
+    rmd_files,
+    list.files(
+      path = file.path(path),
+      pattern = "\\.Rmd$",
+      full.names = TRUE,
+      ignore.case = TRUE,
+      recursive = FALSE
+    )
+  )
+
   read_me <- which(tolower(basename(rmd_files)) == "readme.rmd")
-  
+
   if (length(read_me) > 0) {
     rmd_files <- rmd_files[-read_me]
   }
-  
+
   if (length(rmd_files) > 0) {
-    
     packages_to_add <- c(packages_to_add, "knitr", "rmarkdown")
   }
-  
-  
+
   ## Search for qmd ----
-  
-  qmd_files <- list.files(path = file.path(path, directory), 
-                          pattern = "\\.qmd$", full.names = TRUE, 
-                          ignore.case = TRUE, recursive = TRUE)
-  
-  qmd_files <- c(qmd_files,
-                 list.files(path = file.path(path), pattern = "\\.qmd$", 
-                            full.names = TRUE, ignore.case = TRUE, 
-                            recursive = FALSE))
-  
+
+  qmd_files <- list.files(
+    path = file.path(path, directory),
+    pattern = "\\.qmd$",
+    full.names = TRUE,
+    ignore.case = TRUE,
+    recursive = TRUE
+  )
+
+  qmd_files <- c(
+    qmd_files,
+    list.files(
+      path = file.path(path),
+      pattern = "\\.qmd$",
+      full.names = TRUE,
+      ignore.case = TRUE,
+      recursive = FALSE
+    )
+  )
+
   read_me <- which(tolower(basename(qmd_files)) == "readme.qmd")
-  
+
   if (length(read_me) > 0) {
     qmd_files <- qmd_files[-read_me]
   }
-  
+
   if (length(qmd_files) > 0) {
-    
     packages_to_add <- c(packages_to_add, "knitr", "rmarkdown")
   }
-  
-  
+
   ## Append files ----
-  
+
   md_files <- c(rmd_files, qmd_files)
-  
-  
+
   ## No md files in `directory` ----
-  
+
   if (!length(md_files)) {
-    
-    return(list("depends" = NULL,"imports" = NULL))
+    return(list("depends" = NULL, "imports" = NULL))
   }
-  
-  
+
   ## Read md files ----
-  
+
   content <- lapply(md_files, function(x) readLines(con = x, warn = FALSE))
-  
-  
+
   ## Extract code chunks ----
-  
+
   content <- get_code_chunk(content)
-  
-    
+
   ## Remove comments ----
-    
+
   content <- remove_comment_lines(content)
-    
-    
+
   ## Remove messages ----
-    
+
   content <- remove_messages(content)
-    
-    
+
   ## Functions called as pkg::fun() ----
-  
+
   deps_imports <- get_colon_syntax_deps(content)
-  
-  
+
   ## Add additional packages ----
-  
+
   deps_imports <- c(deps_imports, packages_to_add)
   deps_imports <- sort(unique(deps_imports))
-  
-  
+
   ## Attached Packages (library & require) ----
-  
+
   deps_depends <- get_attached_deps(content)
-  
-  
+
   ## Remove duplicates ----
-  
+
   pos <- which(deps_imports %in% deps_depends)
-  
+
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Remove project name ----
-  
+
   pos <- which(deps_depends == basename(path))
   if (length(pos) > 0) deps_depends <- deps_depends[-pos]
-  
+
   pos <- which(deps_imports == basename(path))
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Clean objects ----
-  
+
   if (length(deps_depends) == 0) deps_depends <- NULL
   if (length(deps_imports) == 0) deps_imports <- NULL
-  
+
   list("depends" = deps_depends, "imports" = deps_imports)
 }
 
 
 #' **Remove comment lines**
-#' 
+#'
 #' Remove comment lines in .R files
-#' 
+#'
 #' @noRd
 
 remove_comment_lines <- function(x) {
-  
   lapply(x, function(x) {
-    gsub("#.*", "", x)  
+    gsub("#.*", "", x)
   })
 }
-
 
 
 #' **Remove comment lines in @examples**
-#' 
+#'
 #' Remove comment lines in .R files in `@examples`
-#' 
+#'
 #' @noRd
 
 remove_rd_comment_lines <- function(x) {
-  
   lapply(x, function(x) {
-    gsub("(#'.*)(#.*)", "\\1", x)  
+    gsub("(#'.*)(#.*)", "\\1", x)
   })
 }
 
 
-
 #' **Remove messages**
-#' 
+#'
 #' Remove messages in `stop()`, `messages()`, `cat()`, `print()`, etc.
-#' 
+#'
 #' @noRd
 
 remove_messages <- function(x) {
-  
   x <- lapply(x, function(x) gsub("\".{0,}\'.{0,}\'.{0,}\"", "", x))
   x <- lapply(x, function(x) gsub("\'.{0,}\".{0,}\".{0,}\'", "", x))
   x <- lapply(x, function(x) gsub("\".{0,}\\\".{0,}\\\".{0,}\"", "", x))
   x <- lapply(x, function(x) gsub("\'.{0,}\\\'.{0,}\\\'.{0,}\'", "", x))
-  
+
   x
 }
 
 
-
 #' **Detect packages called with the double colon syntax**
-#' 
+#'
 #' Detect packages called with the double colon syntax (i.e. `foo::bar()`).
-#' 
+#'
 #' @noRd
 
 get_colon_syntax_deps <- function(x) {
-  
-  pattern <- paste0("[A-Z|a-z|0-9|\\.]{1,}\\s{0,}", 
-                    "::", 
-                    "\\s{0,}[A-Z|a-z|0-9|\\.|_]{1,}")
-  
+  pattern <- paste0(
+    "[A-Z|a-z|0-9|\\.]{1,}\\s{0,}",
+    "::",
+    "\\s{0,}[A-Z|a-z|0-9|\\.|_]{1,}"
+  )
+
   funs <- unlist(lapply(x, function(x) {
     unlist(regmatches(x, gregexpr(pattern, x)))
   }))
-  
+
   funs <- gsub("\\s", "", funs)
-  
+
   deps <- strsplit(funs, "::")
   deps <- lapply(deps, function(x) x[1])
   deps <- sort(unique(unlist(deps)))
-  
+
   if (length(deps) == 0) deps <- NULL
-  
+
   deps
 }
-
 
 
 #' **Detect attached packages**
-#' 
+#'
 #' Detect attached packages, i.e. called by `library()` and `require()`.
-#' 
+#'
 #' @noRd
 
 get_attached_deps <- function(x) {
-  
-  pattern <- c(paste0("library\\s{0,}\\(\\s{0,}([A-Z|a-z|0-9|\\.]{1,}|",
-                      "\"\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\"|",
-                      "\'\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\')"),
-               paste0("require\\s{0,}\\(\\s{0,}([A-Z|a-z|0-9|\\.]{1,}|",
-                      "\"\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\"|",
-                      "\'\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\')"))
+  pattern <- c(
+    paste0(
+      "library\\s{0,}\\(\\s{0,}([A-Z|a-z|0-9|\\.]{1,}|",
+      "\"\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\"|",
+      "\'\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\')"
+    ),
+    paste0(
+      "require\\s{0,}\\(\\s{0,}([A-Z|a-z|0-9|\\.]{1,}|",
+      "\"\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\"|",
+      "\'\\s{0,}[A-Z|a-z|0-9|\\.]{1,}\\s{0,}\')"
+    )
+  )
   pattern <- paste0(pattern, collapse = "|")
-  
+
   deps <- unlist(lapply(x, function(x) {
     unlist(regmatches(x, gregexpr(pattern, x)))
   }))
-  
+
   deps <- gsub("\\s", "", deps)
   deps <- gsub("library\\(|require\\(|\"|\'", "", deps)
-  
+
   if (length(deps) == 0) deps <- NULL
-  
+
   deps
 }
 
 
-
 #' **Extract Rmd and qmd code chunks**
-#' 
+#'
 #' Extract `.Rmd` and `.qmd` code chunks and inline chunks.
-#' 
+#'
 #' @noRd
 
 get_code_chunk <- function(x) {
-  
   lapply(x, function(x) {
-    
     chunks <- NULL
-    
+
     back_ticks <- grep("```", x)
-    
+
     if (length(back_ticks) > 0) {
-      
       back_ticks <- data.frame(
-        "start" = back_ticks[seq(1, length(back_ticks), by = 2)], 
-        "end"   = back_ticks[seq(2, length(back_ticks), by = 2)])
+        "start" = back_ticks[seq(1, length(back_ticks), by = 2)],
+        "end" = back_ticks[seq(2, length(back_ticks), by = 2)]
+      )
 
       for (i in 1:nrow(back_ticks)) {
-
-        if (length(grep("```\\s{0,}\\{\\s{0,}r", x[back_ticks[i, "start"]])) > 0) {
-
-          chunks <- c(chunks, 
-            x[(back_ticks[i, "start"] + 1):(back_ticks[i, "end"] - 1)])
+        if (
+          length(grep("```\\s{0,}\\{\\s{0,}r", x[back_ticks[i, "start"]])) > 0
+        ) {
+          chunks <- c(
+            chunks,
+            x[(back_ticks[i, "start"] + 1):(back_ticks[i, "end"] - 1)]
+          )
         }
-      } 
+      }
     }
-    
+
     inline_chunks <- x[grep("`r\\s{1,}.*`", x)]
-    
+
     c(chunks, inline_chunks)
   })
 }
 
 
-
 #' **List non standard folders**
-#' 
+#'
 #' List non standard folders (i.e. `analyses/`, `paper/`, `data/`, etc.).
-#' 
+#'
 #' @noRd
 
 list_extra_folders <- function() {
-  
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
+
   folders <- list.dirs(path, full.names = FALSE, recursive = FALSE)
-  
-  
+
   ## Remove hidden folders ----
-  
+
   hidden_folders <- grep("^\\.", folders)
-  
+
   if (length(hidden_folders) > 0) {
     folders <- folders[-hidden_folders]
   }
-  
-  
+
   ## Remove standard folders ----
-  
-  folders <- folders[!(folders %in% 
-                         c("inst", "man", "R", "tests", "vignettes", "renv"))]
-  
+
+  folders <- folders[
+    !(folders %in%
+      c("inst", "man", "R", "tests", "vignettes", "renv"))
+  ]
+
   if (length(folders) == 0) folders <- NULL
-  
+
   folders
 }
 
 
-
 #' **Detect dependencies in non standard folders**
-#' 
-#' Detect dependencies in `.R` (code and examples), `.Rmd` and `.qmd` written 
+#'
+#' Detect dependencies in `.R` (code and examples), `.Rmd` and `.qmd` written
 #' as `pkg::fun()`, `library(pkg)`, and `require(pkg)`.
-#' 
+#'
 #' @noRd
 
 get_deps_in_extra <- function() {
-  
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
+
   folders <- list_extra_folders()
-  
+
   if (is.null(folders)) {
-    
     return(list("depends" = NULL, "imports" = NULL))
   }
-  
-  
+
   ## Get dependencies ----
-  
+
   deps_depends <- NULL
   deps_imports <- NULL
-  
+
   for (folder in folders) {
-    
     deps <- get_deps_in_functions(folder)
     deps_depends <- c(deps_depends, deps$"depends")
     deps_imports <- c(deps_imports, deps$"imports")
-    
+
     deps <- get_deps_in_examples(folder)
     deps_depends <- c(deps_depends, deps$"depends")
     deps_imports <- c(deps_imports, deps$"imports")
-    
+
     deps <- get_deps_in_markdown(folder)
     deps_depends <- c(deps_depends, deps$"depends")
     deps_imports <- c(deps_imports, deps$"imports")
   }
-  
-  
+
   ## Remove duplicates ----
-  
+
   pos <- which(deps_imports %in% deps_depends)
-  
+
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Remove project name ----
-  
+
   pos <- which(deps_depends == basename(path))
   if (length(pos) > 0) deps_depends <- deps_depends[-pos]
-  
+
   pos <- which(deps_imports == basename(path))
   if (length(pos) > 0) deps_imports <- deps_imports[-pos]
-  
-  
+
   ## Clean objects ----
-  
+
   if (length(deps_depends) == 0) deps_depends <- NULL
   if (length(deps_imports) == 0) deps_imports <- NULL
-  
+
   list("depends" = deps_depends, "imports" = deps_imports)
 }

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -1,59 +1,40 @@
-#' #' **Open a file in editor**
-#' #' 
-#' #' @noRd
-#' 
-#' edit_file <- function(path) {
-#'   
-#'   if (rstudioapi::isAvailable() && rstudioapi::hasFun("navigateToFile")) {
-#'     
-#'     rstudioapi::navigateToFile(path)
-#'     
-#'   } else {
-#'     
-#'     utils::file.edit(path)  
-#'   }
-#'   
-#'   invisible(NULL)
-#' }
-
-
-
 #' **Read DESCRIPTION content**
-#' 
+#'
 #' @noRd
 
-read_descr_file <- function() { 
-  
+read_descr_file <- function() {
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
+
   col_names <- colnames(read.dcf(file.path(path, "DESCRIPTION")))
-  
+
   descr <- read.dcf(file.path(path, "DESCRIPTION"), keep.white = col_names)
-  
+
   if (nrow(descr) != 1) {
     stop("Malformed 'DESCRIPTION' file", call. = FALSE)
   }
-  
+
   as.data.frame(descr, stringsAsFactors = FALSE)
 }
 
 
-
 #' **Write DESCRIPTION (erase content)**
-#' 
+#'
 #' @noRd
 
-write_descr_file <- function(descr_file) { 
-  
-  
+write_descr_file <- function(descr_file) {
   check_for_descr_file()
-  
+
   path <- path_proj()
-  
-  write.dcf(descr_file, file = file.path(path, "DESCRIPTION"), indent = 4, 
-            width = 80, keep.white = colnames(descr_file))
-  
+
+  write.dcf(
+    descr_file,
+    file = file.path(path, "DESCRIPTION"),
+    indent = 4,
+    width = 80,
+    keep.white = colnames(descr_file)
+  )
+
   invisible(NULL)
 }

--- a/R/utils-msg.R
+++ b/R/utils-msg.R
@@ -1,50 +1,43 @@
 #' @noRd
 
 msg_done <- function(..., indent = "") {
-  
   x <- paste(...)
   x <- msg_bullet(x, indent = indent, cli::col_green(cli::symbol$"tick"))
   cli::cat_line(x)
-  
+
   invisible(NULL)
 }
-
 
 
 #' @noRd
 
 msg_oops <- function(..., indent = "") {
-  
   x <- paste(...)
   x <- msg_bullet(x, indent = indent, cli::col_red(cli::symbol$"cross"))
   cli::cat_line(x)
-  
+
   invisible(NULL)
 }
-
 
 
 #' @noRd
 
 msg_info <- function(..., indent = "") {
-  
   x <- paste(...)
   x <- msg_bullet(x, indent = indent, cli::col_blue("(*)"))
   cli::cat_line(x)
-  
+
   invisible(NULL)
 }
-
 
 
 #' @noRd
 
 msg_line <- function(..., indent = "") {
-  
   x <- paste(...)
   x <- paste0(indent, x)
   cli::cat_line(x)
-  
+
   invisible(NULL)
 }
 
@@ -52,47 +45,40 @@ msg_line <- function(..., indent = "") {
 #' @noRd
 
 msg_value <- function(...) {
-  
   x <- unlist(list(...))
-  
+
   if (is.character(x)) {
     x <- encodeString(x, quote = "'")
   }
-  
+
   invisible(paste0(cli::col_blue(x), collapse = ", "))
 }
-
 
 
 #' @noRd
 
 msg_code <- function(...) {
-  
   x <- unlist(list(...))
-  
+
   if (is.character(x)) {
     x <- encodeString(x, quote = "`")
   }
-  
+
   invisible(paste0(cli::col_silver(x), collapse = ", "))
 }
-
 
 
 #' @noRd
 
 msg_bullet <- function(x, indent = "", bullet = cli::symbol$"bullet") {
-  
   bullet <- paste0(indent, bullet, " ")
   msg_indent(x, bullet, "  ")
 }
 
 
-
 #' @noRd
 
-msg_indent <- function (x, first = "  ", indent = first) {
-  
+msg_indent <- function(x, first = "  ", indent = first) {
   x <- gsub("\n\\s", "\n", x)
   x <- gsub("\n", paste0("\n", indent), x)
   paste0(first, x)

--- a/R/utils-proj.R
+++ b/R/utils-proj.R
@@ -1,66 +1,65 @@
 #' **Get project root path**
-#' 
+#'
 #' @noRd
 
 path_proj <- function() {
-  
   is_descr_file <- file.exists(file.path(getwd(), "DESCRIPTION"))
-  is_here_file  <- file.exists(file.path(getwd(), ".here"))
+  is_here_file <- file.exists(file.path(getwd(), ".here"))
   is_git_folder <- dir.exists(file.path(getwd(), ".git"))
-  
-  is_rproj_file <- ifelse(length(list.files(getwd(), pattern = "\\.Rproj")) > 0,
-                          TRUE, FALSE)
-  
+
+  is_rproj_file <- ifelse(
+    length(list.files(getwd(), pattern = "\\.Rproj")) > 0,
+    TRUE,
+    FALSE
+  )
+
   if ((is_descr_file + is_here_file + is_git_folder + is_rproj_file) == 0) {
-    stop("It appears that the current working directory is not a valid ", 
-         "project or package. Read more at ", 
-         "'https://usethis.r-lib.org/reference/proj_utils.html'", call. = FALSE)
+    stop(
+      "It appears that the current working directory is not a valid ",
+      "project or package. Read more at ",
+      "'https://usethis.r-lib.org/reference/proj_utils.html'",
+      call. = FALSE
+    )
   }
-  
+
   getwd()
 }
 
 
-
 #' **Check if a DESCRIPTION file exists**
-#' 
+#'
 #' @noRd
 
 check_for_descr_file <- function() {
-  
   path <- path_proj()
-  
+
   if (!file.exists(file.path(path, "DESCRIPTION"))) {
     stop("No 'DESCRIPTION' file found", call. = FALSE)
   }
-  
+
   invisible(NULL)
 }
 
 
-
 #' **Get project name**
-#' 
+#'
 #' @noRd
 
 get_package_name <- function() {
-  
   path <- path_proj()
-  
+
   basename(path)
 }
 
 
-
 #' **Get `roxygen2` package version**
-#' 
+#'
 #' @noRd
 
 get_roxygen2_version <- function() {
-  
   if (!length(find.package("roxygen2", quiet = TRUE))) {
     stop("The package 'roxygen2' is not install", call. = FALSE)
   }
-  
+
   as.character(utils::packageVersion("roxygen2"))
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -115,7 +115,7 @@ can be created and added to an existing project with the function
 Please cite `rdeps` as: 
 
 > Casajus Nicolas (`r format(Sys.Date(), "%Y")`) rdeps: An R 
-package to identify external packages used in a project. R package version 0.2,
+package to identify external packages used in a project. R package version 0.3,
 <https://github.com/frbcesab/rdeps/>.
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -6,10 +6,12 @@ output: github_document
 
 
 ```{r, include = FALSE}
-knitr::opts_chunk$set(collapse  = TRUE,
-                      comment   = "#>",
-                      fig.path  = "man/figures/",
-                      out.width = "100%")
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/",
+  out.width = "100%"
+)
 ```
 
 
@@ -57,7 +59,7 @@ Different types of dependencies are handled:
 - if the package is called with `library(foo)` or `require(foo)`, 
 it will be added to the section **Depends** of the `DESCRIPTION` file 
 (except for vignettes and tests);
-- if the package is called with `foo::bar()`,
+- if the package is called with `foo::bar()` or `use("foo", "bar")`,
 it will be added to the section **Imports** of the `DESCRIPTION` file
 (except for vignettes and tests);
 - if the package is only used in vignettes or tests,

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Different types of dependencies are handled:
 - if the package is called with `library(foo)` or `require(foo)`, it
   will be added to the section **Depends** of the `DESCRIPTION` file
   (except for vignettes and tests);
-- if the package is called with `foo::bar()` or `use("foo", "bar")`, it 
-  will be added to the section **Imports** of the `DESCRIPTION` file 
+- if the package is called with `foo::bar()` or `use("foo", "bar")`, it
+  will be added to the section **Imports** of the `DESCRIPTION` file
   (except for vignettes and tests);
 - if the package is only used in vignettes or tests, it will be added to
   the section **Suggests** of the `DESCRIPTION` file.
@@ -93,7 +93,7 @@ the function
 
 Please cite `rdeps` as:
 
-> Casajus Nicolas (2024) rdeps: An R package to identify external
+> Casajus Nicolas (2025) rdeps: An R package to identify external
 > packages used in a project. R package version 0.2,
 > <https://github.com/frbcesab/rdeps/>.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ the function
 Please cite `rdeps` as:
 
 > Casajus Nicolas (2025) rdeps: An R package to identify external
-> packages used in a project. R package version 0.2,
+> packages used in a project. R package version 0.3,
 > <https://github.com/frbcesab/rdeps/>.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Different types of dependencies are handled:
 - if the package is called with `library(foo)` or `require(foo)`, it
   will be added to the section **Depends** of the `DESCRIPTION` file
   (except for vignettes and tests);
-- if the package is called with `foo::bar()`, it will be added to the
-  section **Imports** of the `DESCRIPTION` file (except for vignettes
-  and tests);
+- if the package is called with `foo::bar()` or `use("foo", "bar")`, it 
+  will be added to the section **Imports** of the `DESCRIPTION` file 
+  (except for vignettes and tests);
 - if the package is only used in vignettes or tests, it will be added to
   the section **Suggests** of the `DESCRIPTION` file.
 

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,8 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+exclude = []
+default-exclude = true

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,7 +4,7 @@ bibentry(
   bibtype = "Manual",
   title   = "rdeps: {An} {R} package to identify external packages used in a project",
   author  = c(person("Casajus Nicolas")),
-  year    = "2023",
-  note    = "R package version 0.2",
+  year    = "2025",
+  note    = "R package version 0.3",
   url     = "https://github.com/frbcesab/rdeps"
 )

--- a/inst/package-sticker/package-sticker.R
+++ b/inst/package-sticker/package-sticker.R
@@ -2,47 +2,49 @@
 #' Create an Hexagonal Sticker for the Package
 #'
 
-
 # install.packages(c("png", "ggplot2", "hexSticker", "grid", "ggpubr"))
-
 
 rlogo <- png::readPNG(here::here("inst", "package-sticker", "logo.png"))
 rlogo <- grid::rasterGrob(rlogo, interpolate = TRUE)
 
 p <- ggplot2::ggplot() +
-  ggplot2::annotation_custom(rlogo, xmin = -Inf, xmax = Inf, ymin = -Inf, 
-                             ymax = Inf) +
+  ggplot2::annotation_custom(
+    rlogo,
+    xmin = -Inf,
+    xmax = Inf,
+    ymin = -Inf,
+    ymax = Inf
+  ) +
   ggplot2::theme_void() +
   ggpubr::theme_transparent()
 
 hexSticker::sticker(
+  subplot = p,
+  package = "rdeps",
+  filename = here::here("man", "figures", "logo.png"),
+  dpi = 600,
 
-  subplot   = p,
-  package   = "rdeps",
-  filename  = here::here("man", "figures", "logo.png"),
-  dpi       = 600,
+  p_size = 35.0, # Title
+  u_size = 8.0, # URL
+  p_family = "Aller_Rg",
 
-  p_size    = 35.0,         # Title
-  u_size    =  8.0,         # URL
-  p_family  = "Aller_Rg",
+  p_color = "#d65d0e", # Title
+  h_fill = "#3c3836", # Background
+  h_color = "#b57614", # Border
+  u_color = "#d65d0e", # URL
 
-  p_color   = "#d65d0e",   # Title
-  h_fill    = "#3c3836",   # Background
-  h_color   = "#b57614",   # Border
-  u_color   = "#d65d0e",   # URL
+  p_x = 1.00, # Title
+  p_y = 0.60, # Title
+  s_x = 1.00, # Subplot
+  s_y = 1.25, # Subplot
 
-  p_x       = 1.00,        # Title
-  p_y       = 0.60,        # Title
-  s_x       = 1.00,        # Subplot
-  s_y       = 1.25,        # Subplot
+  s_width = 1.25, # Subplot
+  s_height = 1.25, # Subplot
 
-  s_width   = 1.25,        # Subplot
-  s_height  = 1.25,        # Subplot
-
-  url       = "https://frbcesab.github.io/rdeps",
+  url = "https://frbcesab.github.io/rdeps",
 
   spotlight = TRUE,
-  l_alpha   = 0.10,
-  l_width   = 4,
-  l_height  = 4
+  l_alpha = 0.10,
+  l_width = 4,
+  l_height = 4
 )

--- a/man/add_deps.Rd
+++ b/man/add_deps.Rd
@@ -19,14 +19,15 @@ the function \code{use_description()} of the package \code{usethis}.
 
 All \code{.R}, \code{.Rmd}, and \code{.qmd} files are screened to identify packages
 called by \code{library(foo)}, \code{library("foo")}, \code{library('foo')},
-\code{require(foo)}, \code{require("foo")}, \code{require('foo')} or \code{foo::bar()}.
+\code{require(foo)}, \code{require("foo")}, \code{require('foo')}, \code{foo::bar()} or
+\code{use("foo", "bar")}.
 
 Different types of dependencies are handled with the following rules:
 \itemize{
 \item if a package is called with \code{library(foo)} or \code{require(foo)},
 it will be added to the section \strong{Depends} of the \code{DESCRIPTION} file
 (except for vignettes and tests);
-\item if the package is called with \code{foo::bar()},
+\item if the package is called with \code{foo::bar()} or \code{use("foo", "bar")},
 it will be added to the section \strong{Imports} of the \code{DESCRIPTION} file
 (except for vignettes and tests);
 \item if the package is only used in vignettes or tests,


### PR DESCRIPTION
This PR is linked to #2 and adds a new feature: the detection of packages called by `use()`. For example:

```r
use("tidyr", c("pivot_longer", "pivot_wider"))
```
